### PR TITLE
Use correct Y axis direction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nuklear-backend-wgpurs"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Serhii Plyhun <snuk188@gmail.com>"]
 keywords = ["gui", "interface", "graphics", "gfx", "wgpu-rs"]
 description = "A Wgpu-rs drawing backend for Rust wrapper for Nuklear 2D GUI library"
@@ -15,8 +15,8 @@ name = "nuklear_backend_wgpurs"
 path = "src/lib.rs"
 
 [dependencies]
-log = "~0.3"
-wgpu = "~0.4"
-nuklear-rust = "~0.6"
-glsl-to-spirv = "~0.1"
+log = "^0.4.11"
+wgpu = "^0.4"
+nuklear-rust = "^0.6.2"
+glsl-to-spirv = "^0.1.7"
 


### PR DESCRIPTION
WGPU 0.4 has Y axis pointing Down
nuklear-backend-wgpurs assumes (in projection matrix) it points up, but also knows it must point down and performs costly y coordinate fix by iterating all vertices.
This change removes the costly iteration, and changes the projection matrix to use WGPU 0.4's natural Y axis direction.

The effect is rather dramatic (on my machine, so YMMV).
The iteration (with `const MAX_VERTEX_MEMORY: usize = 512 * 1024;`) used to take 26-50ms, which increased frame render time.
With this gone, overhead of this backend is negligible.